### PR TITLE
uppercase sensor type

### DIFF
--- a/src/examples/test_sensor_factory.cpp
+++ b/src/examples/test_sensor_factory.cpp
@@ -26,8 +26,10 @@ int main(void)
     IntrinsicsOdom2D intr_odom2d;
     IntrinsicsGPSFix intr_gps_fix;
 
-    problem.addSensor("CAMERA",     "left camera",      pq_3d,  &intr_cam);
-    problem.addSensor("CAMERA",     "right camera",     pq_3d,  &intr_cam);
+    problem.addSensor("CAMERA",     "front left camera",      pq_3d,  &intr_cam);
+    problem.addSensor("Camera",     "front right camera",     pq_3d,  &intr_cam);
+    problem.addSensor("CaMeRa",     "back right camera",      pq_3d,  &intr_cam);
+    problem.addSensor("camera",     "back left camera",       pq_3d,  &intr_cam);
     problem.addSensor("ODOM 2D",    "main odometer",    po_2d,  &intr_odom2d);
     problem.addSensor("GPS FIX",    "GPS fix",          p_3d,   &intr_gps_fix);
     problem.addSensor("CAMERA",     "rear camera",      pq_3d,  &intr_cam);

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -49,7 +49,7 @@ void Problem::addSensor(SensorBase* _sen_ptr)
 
 SensorBase* Problem::addSensor(std::string _sen_type, std::string _sen_name, Eigen::VectorXs& _extrinsics, IntrinsicsBase* _intrinsics)
 {
-    SensorBase* sen_ptr = SensorFactory::get()->create(_sen_type, _sen_name, _extrinsics, _intrinsics);
+    SensorBase* sen_ptr = SensorFactory::get()->create(uppercase(_sen_type), _sen_name, _extrinsics, _intrinsics);
     addSensor(sen_ptr);
     return sen_ptr;
 }

--- a/src/problem.h
+++ b/src/problem.h
@@ -23,6 +23,17 @@ struct IntrinsicsBase;
 
 namespace wolf {
 
+namespace
+{
+    std::string uppercase(const std::string& s)
+    {
+        std::string u(s);
+        std::transform(u.begin(), u.end(), u.begin(), ::toupper);
+
+        return u;
+    }
+}
+
 /** \brief Wolf problem node element in the Wolf Tree
  * 
  * A node has five main data members:


### PR DESCRIPTION
Adding a sensor of type "Camera" ends up as : 
$ what():  Unknown Sensor type
$ Aborted (core dumped)

Since sensor types are std::string and uppercase, why couldn't we make easier ?